### PR TITLE
Fix: strip url query params before resolving view function

### DIFF
--- a/mrbenn_panel/views.py
+++ b/mrbenn_panel/views.py
@@ -22,7 +22,7 @@ def open_template(request):
 def _extract_func(request):
     host = request.get_host()
     referrer = request.META['HTTP_REFERER']
-    url_ending = referrer.split(host)[1]
+    url_ending = referrer.split(host)[1].split('?')[0]
     match = resolve(url_ending)
     func, _, _ = match
     return func


### PR DESCRIPTION
This change addresses the issue that urls might have additional url parameters and the function cannot resolve the view, because the django defined urlpattern without any url params cannot be matched. For example the client-site requested url **/some-url/?with=some&params** cannot get matched to the django defined urlpattern **path('some-url/')**. This change addresses this issue and strips off the url params before resolving the view.

@andytwoods, please review this pull request